### PR TITLE
Scratchpkg.conf xz threads option

### DIFF
--- a/scratchpkg.conf
+++ b/scratchpkg.conf
@@ -5,6 +5,7 @@
 # export CFLAGS="-O2 -march=x86-64 -pipe"
 # export CXXFLAGS="${CFLAGS}"
 # export MAKEFLAGS="-j$(nproc)"
+# export XZ_DEFAULTS="-T 0"
 
 # SOURCE_DIR="/var/cache/scratchpkg/sources"
 # PACKAGE_DIR="/var/cache/scratchpkg/packages"


### PR DESCRIPTION
Added to scratchpkg.conf an option to use all threads with xz while compressing pkgs