### PR TITLE
pkgbuild: get cargo index and cache inside the SOURCE_DIR by default.

### DIFF
--- a/pkgbuild
+++ b/pkgbuild
@@ -512,6 +512,7 @@ main() {
 	[ "$CUSTOM_WORK_DIR" ]    && WORK_DIR="$CUSTOM_WORK_DIR"
 	
 	checkdir "$SOURCE_DIR" "$PACKAGE_DIR" "$WORK_DIR"
+	export CARGO_HOME="$SOURCE_DIR/cargo"
 	
 	# show usage
 	[ "$SHOWHELP" ] && {


### PR DESCRIPTION
By default, cargo will download its index and packages under /root/.cargo. With this change, that becomes $SOURCE_DIR/cargo and means that sources downloaded by cargo will downloaded in a subdirectory of the same location other sources already are.